### PR TITLE
Fixed the broken Discord link to the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 <a href= mailto:arsenic.secondary@gmail.com>
 <img src= "https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white"/>
 </a>
-<a href= "https://discord.com/users/Arsenic#9256">
+<a href= "https://discord.com/users/711927506445533205">
 <img src= "https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white"/>
 </a>
 <a href= "https://stackoverflow.com/users/12030775/arsenic?tab=profile">


### PR DESCRIPTION
The link doesn't show your profile info,it simply just redirects to the friends tab and thus, doesn't show your profile info.
## **Earlier:**
![image](https://user-images.githubusercontent.com/50903223/125046996-27bb6c80-e0bc-11eb-9ff2-a497748ecc3a.png)
## **Now:**
![image](https://user-images.githubusercontent.com/50903223/125046481-b085d880-e0bb-11eb-9c48-df31f76082b9.png)

